### PR TITLE
CompatHelper: add new compat entry for OMEinsum at version 0.8, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+OMEinsum = "0.8"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `OMEinsum` package to `0.8`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.